### PR TITLE
fix(usage): Combine usage stats before sending to prometheus

### DIFF
--- a/pkg/ceph_stats.go
+++ b/pkg/ceph_stats.go
@@ -29,10 +29,10 @@ type bucketUsageEntry struct {
 
 type usageCategoryEntry struct {
 	Name          string `json:"category"`
-	BytesSent     int    `json:"bytes_sent"`
-	BytesReceived int    `json:"bytes_received"`
-	Ops           int    `json:"ops"`
-	SuccessfulOps int    `json:"successful_ops"`
+	BytesSent     int64  `json:"bytes_sent"`
+	BytesReceived int64  `json:"bytes_received"`
+	Ops           int64  `json:"ops"`
+	SuccessfulOps int64  `json:"successful_ops"`
 }
 
 func getCephUsageStats(client *http.Client, rgwURL *url.URL, creds *credentials.Credentials) (*usageResponse, error) {


### PR DESCRIPTION
Ceph admin API will sometimes return usage info split between multiple entries. I'm not sure why. But to solve this, we just add them together